### PR TITLE
Change weekly meeting time from CEST to CET

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -28,7 +28,7 @@
         <p>* <a href="https://trello.com/b/snYAVXym">board</a><br/><small>to get an overview of what's going on in the project</small></p>
         <p>* <a href="https://github.com/OpenHospitalityNetwork">source code</a><br/><small>for development and technical discussions</small></p>
         <p>* <a rel="me" href="https://floss.social/@ohn">fediverse</a><br/><small>account to follow for project updates</small></p>
-        <p>* <a href="https://pad.kanthaus.online/ohn">weekly meeting</a><br/><small>on Mondays at 7pm CEST (UTC+2)</small></p>
+        <p>* <a href="https://pad.kanthaus.online/ohn">weekly meeting</a><br/><small>on Mondays at 7pm CET (UTC+1)</small></p>
       </header>
 
       <section>


### PR DESCRIPTION
CEST (UTC+2) becomes CET (UTC+1) after the reset of [Daylight Saving Time](https://en.wikipedia.org/wiki/Daylight_saving_time).

This should be reversed in spring.